### PR TITLE
[BC] Added ability to pass `parameters` argument to be sent to the server with the request.

### DIFF
--- a/src/AbstractEntity.js
+++ b/src/AbstractEntity.js
@@ -515,6 +515,9 @@ export default class AbstractEntity {
 	 *        compatible with this entity's structure so that they can be
 	 *        directly assigned to the entity, and will be automatically
 	 *        serialized before submitting to the server.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
 	 * @param {{
 	 *            timeout: number=,
 	 *            ttl: number=,
@@ -531,7 +534,7 @@ export default class AbstractEntity {
 	 *         entities or {@code null} constructed from the response body if
 	 *         this entity class has the {@code inlineResponseBody} flag set.
 	 */
-	static create(restClient, data, options = {}, parentEntity = null) {
+	static create(restClient, data, parameters = {}, options = {}, parentEntity = null) {
 		// We create an entity-like object so that we can serialize the data
 		// and properly create a new entity instance later in the REST API
 		// client.
@@ -543,7 +546,7 @@ export default class AbstractEntity {
 
 		let serializedData = fakeEntity.$serialize();
 
-		return restClient.create(this, serializedData, options, parentEntity);
+		return restClient.create(this, serializedData, parameters, options, parentEntity);
 	}
 
 	/**

--- a/src/AbstractEntity.js
+++ b/src/AbstractEntity.js
@@ -554,6 +554,9 @@ export default class AbstractEntity {
 	 *        request should be made.
 	 * @param {(number|string|(number|string)[])} id The ID(s) identifying the
 	 *        entity or group of entities to retrieve.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
 	 * @param {{
 	 *            timeout: number=,
 	 *            ttl: number=,
@@ -570,8 +573,8 @@ export default class AbstractEntity {
 	 *         entities or {@code null} constructed from the response body if
 	 *         this entity class has the {@code inlineResponseBody} flag set.
 	 */
-	static delete(restClient, id, options = {}, parentEntity = null) {
-		return restClient.delete(this, id, options, parentEntity);
+	static delete(restClient, id, parameters = {}, options = {}, parentEntity = null) {
+		return restClient.delete(this, id, parameters, options, parentEntity);
 	}
 
 	/**
@@ -653,6 +656,9 @@ export default class AbstractEntity {
 	 *        structure so that they can be directly assigned to the entity,
 	 *        and will be automatically serialized before submitting to the
 	 *        server.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
 	 * @param {{
 	 *            timeout: number=,
 	 *            ttl: number=,
@@ -667,7 +673,7 @@ export default class AbstractEntity {
 	 *         entities or {@code null} constructed from the response body if
 	 *         this entity class has the {@code inlineResponseBody} flag set.
 	 */
-	patch(data, options = {}) {
+	patch(data, parameters = {}, options = {}) {
 		let resource = this.constructor;
 		let id = this[resource.idFieldName];
 		let client = this[PRIVATE.restClient];
@@ -676,6 +682,7 @@ export default class AbstractEntity {
 			resource,
 			id,
 			serializedData,
+			parameters,
 			options
 		).then((response) => {
 			if (!resource.isImmutable) {
@@ -690,6 +697,9 @@ export default class AbstractEntity {
 	 * Replaces this entity in the REST API resource with this entity's current
 	 * state.
 	 *
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
 	 * @param {{
 	 *            timeout: number=,
 	 *            ttl: number=,
@@ -704,16 +714,19 @@ export default class AbstractEntity {
 	 *         entities or {@code null} constructed from the response body if
 	 *         this entity class has the {@code inlineResponseBody} flag set.
 	 */
-	replace(options = {}) {
+	replace(parameters = {}, options = {}) {
 		let resource = this.constructor;
 		let id = this[resource.idFieldName];
 		let client = this[PRIVATE.restClient];
-		return client.replace(resource, id, this.$serialize(), options);
+		return client.replace(resource, id, this.$serialize(), parameters, options);
 	}
 
 	/**
 	 * Creates this entity in the REST API resource it belongs to.
 	 *
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
 	 * @param {{
 	 *            timeout: number=,
 	 *            ttl: number=,
@@ -728,14 +741,17 @@ export default class AbstractEntity {
 	 *         entities or {@code null} constructed from the response body if
 	 *         this entity class has the {@code inlineResponseBody} flag set.
 	 */
-	create(options = {}) {
+	create(parameters = {}, options = {}) {
 		let client = this[PRIVATE.restClient];
-		return client.create(this.constructor, this.$serialize(), options);
+		return client.create(this.constructor, this.$serialize(), parameters, options);
 	}
 
 	/**
 	 * Deletes this entity from its resource.
 	 *
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
 	 * @param {{
 	 *            timeout: number=,
 	 *            ttl: number=,
@@ -750,9 +766,9 @@ export default class AbstractEntity {
 	 *         entities or {@code null} constructed from the response body if
 	 *         this entity class has the {@code inlineResponseBody} flag set.
 	 */
-	delete(options = {}) {
+	delete(parameters = {}, options = {}) {
 		let id = this[this.constructor.idFieldName];
-		return this.constructor.delete(this[PRIVATE.restClient], id, options);
+		return this.constructor.delete(this[PRIVATE.restClient], id, parameters, options);
 	}
 
 	/**

--- a/src/AbstractRestClient.js
+++ b/src/AbstractRestClient.js
@@ -126,13 +126,13 @@ export default class AbstractRestClient extends RestClient {
 	 * @inheritdoc
 	 * @override
 	 */
-	patch(resource, id, data, options = {}, parentEntity = null) {
+	patch(resource, id, data, parameters = {}, options = {}, parentEntity = null) {
 		return this._prepareAndExecuteRequest(
 			HttpMethod.PATCH,
 			parentEntity,
 			resource,
 			id,
-			{},
+			parameters,
 			data,
 			options
 		);
@@ -142,13 +142,13 @@ export default class AbstractRestClient extends RestClient {
 	 * @inheritdoc
 	 * @override
 	 */
-	replace(resource, id, data, options = {}, parentEntity = null) {
+	replace(resource, id, data, parameters = {}, options = {}, parentEntity = null) {
 		return this._prepareAndExecuteRequest(
 			HttpMethod.PUT,
 			parentEntity,
 			resource,
 			id,
-			{},
+			parameters,
 			data,
 			options
 		);
@@ -158,13 +158,13 @@ export default class AbstractRestClient extends RestClient {
 	 * @inheritdoc
 	 * @override
 	 */
-	create(resource, data, options = {}, parentEntity = null) {
+	create(resource, data, parameters = {}, options = {}, parentEntity = null) {
 		return this._prepareAndExecuteRequest(
 			HttpMethod.POST,
 			parentEntity,
 			resource,
 			null,
-			{},
+			parameters,
 			data,
 			options
 		);
@@ -174,13 +174,13 @@ export default class AbstractRestClient extends RestClient {
 	 * @inheritdoc
 	 * @override
 	 */
-	delete(resource, id, options = {}, parentEntity = null) {
+	delete(resource, id, parameters = {}, options = {}, parentEntity = null) {
 		return this._prepareAndExecuteRequest(
 			HttpMethod.DELETE,
 			parentEntity,
 			resource,
 			id,
-			{},
+			parameters,
 			null,
 			options
 		);

--- a/src/RestClient.js
+++ b/src/RestClient.js
@@ -96,6 +96,9 @@ export default class RestClient {
 	 *        entity or group of entities to modify.
 	 * @param {*} data The data representing the modifications to make to the
 	 *        entity.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
 	 * @param {{
 	 *            timeout: number=,
 	 *            ttl: number=,
@@ -115,7 +118,7 @@ export default class RestClient {
 	 *         the resource is a class extending the {@code AbstractEntity}
 	 *         class and has the {@code inlineResponseBody} flag set.
 	 */
-	patch(resource, id, data, options = {}, parentEntity = null) {}
+	patch(resource, id, data, parameters = {}, options = {}, parentEntity = null) {}
 
 	/**
 	 * Replaces the specified entity in the specified REST resource by a new
@@ -128,6 +131,9 @@ export default class RestClient {
 	 * @param {(number|string|(number|string)[])} id The ID(s) identifying the
 	 *        entity or group of entities to replace.
 	 * @param {*} data The data representing the entity.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
 	 * @param {{
 	 *            timeout: number=,
 	 *            ttl: number=,
@@ -147,7 +153,7 @@ export default class RestClient {
 	 *         the resource is a class extending the {@code AbstractEntity}
 	 *         class and has the {@code inlineResponseBody} flag set.
 	 */
-	replace(resource, id, data, options = {}, parentEntity = null) {}
+	replace(resource, id, data, parameters = {}, options = {}, parentEntity = null) {}
 
 	/**
 	 * Creates a new entity using the provided data in the specified REST
@@ -158,6 +164,9 @@ export default class RestClient {
 	 *
 	 * @param {*} resource The resource in which the entity should be created.
 	 * @param {*} data The data representing the entity.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
 	 * @param {{
 	 *            timeout: number=,
 	 *            ttl: number=,
@@ -177,7 +186,7 @@ export default class RestClient {
 	 *         the resource is a class extending the {@code AbstractEntity}
 	 *         class and has the {@code inlineResponseBody} flag set.
 	 */
-	create(resource, data, options = {}, parentEntity = null) {}
+	create(resource, data, parameters = {}, options = {}, parentEntity = null) {}
 
 	/**
 	 * Deletes the resource entity identified by the specified ID from the
@@ -190,6 +199,9 @@ export default class RestClient {
 	 *        deleted.
 	 * @param {(number|string|(number|string)[])} id The ID(s) identifying the
 	 *        entity or group of entities to delete.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
 	 * @param {{
 	 *            timeout: number=,
 	 *            ttl: number=,
@@ -209,5 +221,5 @@ export default class RestClient {
 	 *         the resource is a class extending the {@code AbstractEntity}
 	 *         class and has the {@code inlineResponseBody} flag set.
 	 */
-	delete(resource, id, options = {}, parentEntity = null) {}
+	delete(resource, id, parameters = {}, options = {}, parentEntity = null) {}
 }

--- a/src/__tests__/AbstractEntitySpec.js
+++ b/src/__tests__/AbstractEntitySpec.js
@@ -331,91 +331,91 @@ describe('AbstractEntity', () => {
 
 		it('should use deserialized entity data in the patch method',
 				(done) => {
-					let entity = new TransformingEntity(restClient, {
-						test: 'testing',
-						testing: 'test',
-						serialized: true
-					});
-					let patchCalled = false;
-					restClientCallbacks.patch = (data) => {
-						patchCalled = true;
-						expect(data).toEqual({
-							test: 'tested',
-							test2: 1,
-							serialized: true
-						});
-					};
-					entity.patch({
-						test: 'tested',
-						test2: 1,
-						onlyDynamic: true
-					}).then(() => {
-						expect(patchCalled).toBeTruthy();
-						expect(Object.assign({}, entity)).toEqual({
-							test: 'tested',
-							testing: 'test',
-							dynamic: true,
-							onlyDynamic: true,
-							test2: 1
-						});
-						done();
-					});
+			let entity = new TransformingEntity(restClient, {
+				test: 'testing',
+				testing: 'test',
+				serialized: true
+			});
+			let patchCalled = false;
+			restClientCallbacks.patch = (data) => {
+				patchCalled = true;
+				expect(data).toEqual({
+					test: 'tested',
+					test2: 1,
+					serialized: true
 				});
+			};
+			entity.patch({
+				test: 'tested',
+				test2: 1,
+				onlyDynamic: true
+			}).then(() => {
+				expect(patchCalled).toBeTruthy();
+				expect(Object.assign({}, entity)).toEqual({
+					test: 'tested',
+					testing: 'test',
+					dynamic: true,
+					onlyDynamic: true,
+					test2: 1
+				});
+				done();
+			});
+		});
 
 		it('should use deserialized entity data in the replace method',
 				(done) => {
-					let entity = new TransformingEntity(restClient, {
-						test: 'testing',
-						testing: 'test',
-						serialized: true
-					});
-					let replaceCalled = false;
-					restClientCallbacks.replace = (data) => {
-						replaceCalled = true;
-						expect(data).toEqual({
-							test: 'tested',
-							testing: 'test',
-							serialized: true
-						});
-					};
-					entity.test = 'tested';
-					entity.replace().then(() => {
-						expect(replaceCalled).toBeTruthy();
-						expect(Object.assign({}, entity)).toEqual({
-							test: 'tested',
-							testing: 'test',
-							dynamic: true
-						});
-						done();
-					});
+			let entity = new TransformingEntity(restClient, {
+				test: 'testing',
+				testing: 'test',
+				serialized: true
+			});
+			let replaceCalled = false;
+			restClientCallbacks.replace = (data) => {
+				replaceCalled = true;
+				expect(data).toEqual({
+					test: 'tested',
+					testing: 'test',
+					serialized: true
 				});
+			};
+			entity.test = 'tested';
+			entity.replace().then(() => {
+				expect(replaceCalled).toBeTruthy();
+				expect(Object.assign({}, entity)).toEqual({
+					test: 'tested',
+					testing: 'test',
+					dynamic: true
+				});
+				done();
+			});
+		});
 
 		it('should use deserialized entity data in the dynamic create method',
 				(done) => {
-					let entity = new TransformingEntity(restClient, {
-						test: 'testing',
-						testing: 'test',
-						serialized: true
-					});
-					let createCalled = false;
-					restClientCallbacks.create = (data) => {
-						createCalled = true;
-						expect(data).toEqual({
-							test: 'testing',
-							testing: 'test',
-							serialized: true
-						});
-					};
-					entity.create().then(() => {
-						expect(createCalled).toBeTruthy();
-						expect(Object.assign({}, entity)).toEqual({
-							test: 'testing',
-							testing: 'test',
-							dynamic: true
-						});
-						done();
-					});
+			let entity = new TransformingEntity(restClient, {
+				test: 'testing',
+				testing: 'test',
+				serialized: true
+			});
+			let createCalled = false;
+			restClientCallbacks.create = (data) => {
+				createCalled = true;
+				expect(data).toEqual({
+					test: 'testing',
+					testing: 'test',
+					serialized: true
 				});
+			};
+			entity.create().then(() => {
+				expect(createCalled).toBeTruthy();
+				expect(Object.assign({}, entity)).toEqual({
+					test: 'testing',
+					testing: 'test',
+					dynamic: true
+				});
+				done();
+			});
+		});
 
 		it('should allow declarative property mapping', () => {
 			class DeclarativelyMappedEntity extends Entity {
@@ -448,69 +448,69 @@ describe('AbstractEntity', () => {
 
 		it('should allow declarative property mapping using mapper object',
 				() => {
-					class MappingEntity extends Entity {
-						static get dataFieldMapping() {
-							return {
-								id: {
-									dataFieldName: '_id',
-									serialize(value, processedEntity) {
-										expect(
+			class MappingEntity extends Entity {
+				static get dataFieldMapping() {
+					return {
+						id: {
+							dataFieldName: '_id',
+							serialize(value, processedEntity) {
+								expect(
 									processedEntity instanceof MappingEntity
 								).toBe(true);
-										return -value;
-									},
-									deserialize(value, processedEntity) {
-										expect(
+								return -value;
+							},
+							deserialize(value, processedEntity) {
+								expect(
 									processedEntity instanceof MappingEntity
 								).toBe(true);
-										return -value;
-									}
-								},
-								foo: {
-									dataFieldName: null,
-									serialize(value, processedEntity) {
-										return value;
-									},
-									deserialize(value, processedEntity) {
-										return value;
-									}
-								},
-								bar: {
-									dataFieldName: 'bar',
-									serialize(value, processedEntity) {
-										return value;
-									},
-									deserialize(value, processedEntity) {
-										return value;
-									}
-								}
-							};
+								return -value;
+							}
+						},
+						foo: {
+							dataFieldName: null,
+							serialize(value, processedEntity) {
+								return value;
+							},
+							deserialize(value, processedEntity) {
+								return value
+							}
+						},
+						bar: {
+							dataFieldName: 'bar',
+							serialize(value, processedEntity) {
+								return value;
+							},
+							deserialize(value, processedEntity) {
+								return value
+							}
 						}
+					};
+				}
 			}
 
-					let entity = new MappingEntity(restClient, {
-						_id: 123,
-						foo: 'a',
-						bar: 'b'
-					});
-					expect(Object.assign({}, entity)).toEqual({
-						id: -123,
-						foo: 'a',
-						bar: 'b'
-					});
-					expect(entity.$serialize()).toEqual({
-						_id: 123,
-						foo: 'a',
-						bar: 'b'
-					});
-				});
+			let entity = new MappingEntity(restClient, {
+				_id: 123,
+				foo: 'a',
+				bar: 'b'
+			});
+			expect(Object.assign({}, entity)).toEqual({
+				id: -123,
+				foo: 'a',
+				bar: 'b'
+			});
+			expect(entity.$serialize()).toEqual({
+				_id: 123,
+				foo: 'a',
+				bar: 'b'
+			});
+		});
 
 		it('should allow declarative property mapping using mapper classes',
 				() => {
-					class MappingEntity extends Entity {
-						static get dataFieldMapping() {
-							return {
-								id: AbstractDataFieldMapper.makeMapper(
+			class MappingEntity extends Entity {
+				static get dataFieldMapping() {
+					return {
+						id: AbstractDataFieldMapper.makeMapper(
 							'_id',
 							(value, processedEntity) => {
 								expect(
@@ -525,36 +525,36 @@ describe('AbstractEntity', () => {
 								return -value;
 							}
 						),
-								foo: AbstractDataFieldMapper.makeMapper(
+						foo: AbstractDataFieldMapper.makeMapper(
 							null,
 							value => value,
 							value => value
 						),
-								bar: AbstractDataFieldMapper.makeMapper(
+						bar: AbstractDataFieldMapper.makeMapper(
 							'bar',
 							value => value,
 							value => value
 						)
-							};
-						}
+					};
+				}
 			}
 
-					let entity = new MappingEntity(restClient, {
-						_id: 123,
-						foo: 'a',
-						bar: 'b'
-					});
-					expect(Object.assign({}, entity)).toEqual({
-						id: -123,
-						foo: 'a',
-						bar: 'b'
-					});
-					expect(entity.$serialize()).toEqual({
-						_id: 123,
-						foo: 'a',
-						bar: 'b'
-					});
-				});
+			let entity = new MappingEntity(restClient, {
+				_id: 123,
+				foo: 'a',
+				bar: 'b'
+			});
+			expect(Object.assign({}, entity)).toEqual({
+				id: -123,
+				foo: 'a',
+				bar: 'b'
+			});
+			expect(entity.$serialize()).toEqual({
+				_id: 123,
+				foo: 'a',
+				bar: 'b'
+			});
+		});
 
 		it('should allow create field mappers from entity classes', () => {
 			class Session extends Entity {}
@@ -719,8 +719,8 @@ describe('AbstractEntity', () => {
 
 		it('should be possible to configure inlineResponseBody exactly once',
 				() => {
-					testStaticProperty('inlineResponseBody', false, false, true);
-				});
+			testStaticProperty('inlineResponseBody', false, false, true);
+		});
 
 		it('should be possible to configure propTypes exactly once', () => {
 			testStaticProperty('propTypes', {}, false, { id: 'integer:>0' });
@@ -728,8 +728,8 @@ describe('AbstractEntity', () => {
 
 		it('should be possible to configure dataFieldMapping exactly once',
 				() => {
-					testStaticProperty('dataFieldMapping', {}, false, { id: '_id' });
-				});
+			testStaticProperty('dataFieldMapping', {}, false, { id: '_id' });
+		});
 
 		it('should be possible to configure isImmutable exactly once', () => {
 			testStaticProperty('isImmutable', false, false, true);

--- a/src/__tests__/AbstractEntitySpec.js
+++ b/src/__tests__/AbstractEntitySpec.js
@@ -35,7 +35,7 @@ describe('AbstractEntity', () => {
 			return Promise.resolve(restResult);
 		}
 
-		patch(resource, id, data, options = {}, parentEntity = null) {
+		patch(resource, id, data, parameters = {}, options = {}, parentEntity = null) {
 			calledClientMethods.patch = true;
 			if (restClientCallbacks.patch) {
 				restClientCallbacks.patch(data);
@@ -43,7 +43,7 @@ describe('AbstractEntity', () => {
 			return Promise.resolve(restResult);
 		}
 
-		replace(resource, id, data, options = {}, parentEntity = null) {
+		replace(resource, id, data, parameters = {}, options = {}, parentEntity = null) {
 			calledClientMethods.replace = true;
 			if (restClientCallbacks.replace) {
 				restClientCallbacks.replace(data);
@@ -51,7 +51,7 @@ describe('AbstractEntity', () => {
 			return Promise.resolve(restResult);
 		}
 
-		create(resource, data, options = {}, parentEntity = null) {
+		create(resource, data, parameters = {}, options = {}, parentEntity = null) {
 			calledClientMethods.create = true;
 			if (restClientCallbacks.create) {
 				restClientCallbacks.create(data);
@@ -59,7 +59,7 @@ describe('AbstractEntity', () => {
 			return Promise.resolve(restResult);
 		}
 
-		delete(resource, id, options = {}, parentEntity = null) {
+		delete(resource, id, parameters = {}, options = {}, parentEntity = null) {
 			calledClientMethods.delete = true;
 			return Promise.resolve(restResult);
 		}

--- a/src/__tests__/AbstractEntitySpec.js
+++ b/src/__tests__/AbstractEntitySpec.js
@@ -4,7 +4,7 @@ import AbstractEntity from '../AbstractEntity';
 import AbstractRestClient from '../AbstractRestClient';
 
 describe('AbstractEntity', () => {
-	
+
 	class Entity extends AbstractEntity {
 		static get resourceName() {
 			return 'foo';
@@ -18,25 +18,31 @@ describe('AbstractEntity', () => {
 			return true;
 		}
 	}
-	
+
 	let restResult;
 	let calledClientMethods;
+	let parametersToPass;
+	let passedParameters;
 	let restClient;
 	let restClientCallbacks;
-	
+
 	class RestClient extends AbstractRestClient {
 		list(resource, parameters = {}, options = {}, parentEntity = null) {
 			calledClientMethods.list = true;
+			passedParameters = parameters;
 			return Promise.resolve(restResult);
 		}
 
 		get(resource, id, parameters = {}, options = {}, parentEntity = null) {
 			calledClientMethods.get = true;
+			passedParameters = parameters;
 			return Promise.resolve(restResult);
 		}
 
 		patch(resource, id, data, parameters = {}, options = {}, parentEntity = null) {
 			calledClientMethods.patch = true;
+			passedParameters = parameters;
+
 			if (restClientCallbacks.patch) {
 				restClientCallbacks.patch(data);
 			}
@@ -45,6 +51,8 @@ describe('AbstractEntity', () => {
 
 		replace(resource, id, data, parameters = {}, options = {}, parentEntity = null) {
 			calledClientMethods.replace = true;
+			passedParameters = parameters;
+
 			if (restClientCallbacks.replace) {
 				restClientCallbacks.replace(data);
 			}
@@ -53,6 +61,8 @@ describe('AbstractEntity', () => {
 
 		create(resource, data, parameters = {}, options = {}, parentEntity = null) {
 			calledClientMethods.create = true;
+			passedParameters = parameters;
+
 			if (restClientCallbacks.create) {
 				restClientCallbacks.create(data);
 			}
@@ -61,10 +71,12 @@ describe('AbstractEntity', () => {
 
 		delete(resource, id, parameters = {}, options = {}, parentEntity = null) {
 			calledClientMethods.delete = true;
+			passedParameters = parameters;
+
 			return Promise.resolve(restResult);
 		}
 	}
-	
+
 	beforeEach(() => {
 		restResult = null;
 		calledClientMethods = {
@@ -81,16 +93,18 @@ describe('AbstractEntity', () => {
 			replace: null
 		};
 		restClient = new RestClient(null, null, null, [], []);
+		parametersToPass = { key: 'value' };
+		passedParameters = undefined;
 	});
-	
+
 	it('should reject invalid rest client constructor argument', () => {
 		expect(() => {
 			new Entity(null, {});
 		}).toThrowError(TypeError);
-		
+
 		new Entity(restClient, {});
 	});
-	
+
 	it('should assign data to its instance', () => {
 		let template = new Entity(restClient, {});
 		template.id = 12;
@@ -115,9 +129,10 @@ describe('AbstractEntity', () => {
 
 	it('should allow listing of entities', (done) => {
 		restResult = 123;
-		return Entity.list(restClient).then((response) => {
+		return Entity.list(restClient, parametersToPass).then((response) => {
 			expect(response).toBe(restResult);
 			expect(calledClientMethods.list).toBeTruthy();
+			expect(passedParameters).toEqual(parametersToPass);
 			done();
 		}).catch((error) => {
 			fail(error.stack);
@@ -127,9 +142,10 @@ describe('AbstractEntity', () => {
 
 	it('should allow retrieving a single entity', (done) => {
 		restResult = 234;
-		return Entity.get(restClient, 1).then((response) => {
+		return Entity.get(restClient, 1, parametersToPass).then((response) => {
 			expect(response).toBe(restResult);
 			expect(calledClientMethods.get).toBeTruthy();
+			expect(passedParameters).toEqual(parametersToPass);
 			done();
 		}).catch((error) => {
 			fail(error.stack);
@@ -139,17 +155,20 @@ describe('AbstractEntity', () => {
 
 	it('should allow creating new entities', (done) => {
 		restResult = 345;
-		return Entity.create(restClient, {}).then((response) => {
+		return Entity.create(restClient, {}, parametersToPass).then((response) => {
 			expect(response).toBe(restResult);
 			expect(calledClientMethods.create).toBeTruthy();
+			expect(passedParameters).toEqual(parametersToPass);
 
 			calledClientMethods.create = false;
 			restResult = 456;
+			parametersToPass = Object.assign({}, parametersToPass);
 			let entity = new Entity(restClient, {});
-			return entity.create();
+			return entity.create(parametersToPass);
 		}).then((response) => {
 			expect(response).toBe(restResult);
 			expect(calledClientMethods.create).toBeTruthy();
+			expect(passedParameters).toEqual(parametersToPass);
 
 			done();
 		}).catch((error) => {
@@ -160,17 +179,20 @@ describe('AbstractEntity', () => {
 
 	it('should allow deleting entities', (done) => {
 		restResult = 567;
-		return Entity.delete(restClient, 1).then((response) => {
+		return Entity.delete(restClient, 1, parametersToPass).then((response) => {
 			expect(response).toBe(restResult);
 			expect(calledClientMethods.delete).toBeTruthy();
+			expect(passedParameters).toEqual(parametersToPass);
 
 			calledClientMethods.delete = false;
 			restResult = 678;
+			parametersToPass = Object.assign({}, parametersToPass);
 			let entity = new Entity(restClient, { id: 1 });
-			return entity.delete();
+			return entity.delete(parametersToPass);
 		}).then((response) => {
 			expect(response).toBe(restResult);
 			expect(calledClientMethods.delete).toBeTruthy();
+			expect(passedParameters).toEqual(parametersToPass);
 
 			done();
 		}).catch((error) => {
@@ -182,9 +204,10 @@ describe('AbstractEntity', () => {
 	it('should allow listing of sub-resource entities', (done) => {
 		restResult = 789;
 		let entity = new Entity(restClient, {});
-		entity.list(Entity).then((response) => {
+		entity.list(Entity, parametersToPass).then((response) => {
 			expect(response).toBe(restResult);
 			expect(calledClientMethods.list).toBeTruthy();
+			expect(passedParameters).toEqual(parametersToPass);
 
 			done();
 		}).catch((error) => {
@@ -196,9 +219,10 @@ describe('AbstractEntity', () => {
 	it('should allow fetching of single entities', (done) => {
 		restResult = 890;
 		let entity = new Entity(restClient, {});
-		entity.get(Entity, 1).then((response) => {
+		entity.get(Entity, 1, parametersToPass).then((response) => {
 			expect(response).toBe(restResult);
 			expect(calledClientMethods.get).toBeTruthy();
+			expect(passedParameters).toEqual(parametersToPass);
 
 			done();
 		}).catch((error) => {
@@ -210,9 +234,10 @@ describe('AbstractEntity', () => {
 	it('should allow patching entities', (done) => {
 		restResult = 901;
 		let entity = new Entity(restClient, { id: 1 });
-		entity.patch({ id: 2, test: 'yay' }).then((response) => {
+		entity.patch({ id: 2, test: 'yay' }, parametersToPass).then((response) => {
 			expect(response).toBe(restResult);
 			expect(calledClientMethods.patch).toBeTruthy();
+			expect(passedParameters).toEqual(parametersToPass);
 
 			expect(entity).toEqual(new Entity(restClient, {
 				id: 2,
@@ -229,9 +254,10 @@ describe('AbstractEntity', () => {
 	it('should allow replacing entities', (done) => {
 		restResult = 12;
 		let entity = new Entity(restClient, {});
-		entity.replace().then((response) => {
+		entity.replace(parametersToPass).then((response) => {
 			expect(response).toBe(restResult);
 			expect(calledClientMethods.replace).toBeTruthy();
+			expect(passedParameters).toEqual(parametersToPass);
 
 			done();
 		}).catch((error) => {
@@ -275,7 +301,7 @@ describe('AbstractEntity', () => {
 				dynamic: true
 			});
 		});
-		
+
 		it('should create entities from deserialized data when using static ' +
 				'create()', (done) => {
 			let createCalled = false;
@@ -305,91 +331,91 @@ describe('AbstractEntity', () => {
 
 		it('should use deserialized entity data in the patch method',
 				(done) => {
-			let entity = new TransformingEntity(restClient, {
-				test: 'testing',
-				testing: 'test',
-				serialized: true
-			});
-			let patchCalled = false;
-			restClientCallbacks.patch = (data) => {
-				patchCalled = true;
-				expect(data).toEqual({
-					test: 'tested',
-					test2: 1,
-					serialized: true
+					let entity = new TransformingEntity(restClient, {
+						test: 'testing',
+						testing: 'test',
+						serialized: true
+					});
+					let patchCalled = false;
+					restClientCallbacks.patch = (data) => {
+						patchCalled = true;
+						expect(data).toEqual({
+							test: 'tested',
+							test2: 1,
+							serialized: true
+						});
+					};
+					entity.patch({
+						test: 'tested',
+						test2: 1,
+						onlyDynamic: true
+					}).then(() => {
+						expect(patchCalled).toBeTruthy();
+						expect(Object.assign({}, entity)).toEqual({
+							test: 'tested',
+							testing: 'test',
+							dynamic: true,
+							onlyDynamic: true,
+							test2: 1
+						});
+						done();
+					});
 				});
-			};
-			entity.patch({
-				test: 'tested',
-				test2: 1,
-				onlyDynamic: true
-			}).then(() => {
-				expect(patchCalled).toBeTruthy();
-				expect(Object.assign({}, entity)).toEqual({
-					test: 'tested',
-					testing: 'test',
-					dynamic: true,
-					onlyDynamic: true,
-					test2: 1
-				});
-				done();
-			});
-		});
 
 		it('should use deserialized entity data in the replace method',
 				(done) => {
-			let entity = new TransformingEntity(restClient, {
-				test: 'testing',
-				testing: 'test',
-				serialized: true
-			});
-			let replaceCalled = false;
-			restClientCallbacks.replace = (data) => {
-				replaceCalled = true;
-				expect(data).toEqual({
-					test: 'tested',
-					testing: 'test',
-					serialized: true
+					let entity = new TransformingEntity(restClient, {
+						test: 'testing',
+						testing: 'test',
+						serialized: true
+					});
+					let replaceCalled = false;
+					restClientCallbacks.replace = (data) => {
+						replaceCalled = true;
+						expect(data).toEqual({
+							test: 'tested',
+							testing: 'test',
+							serialized: true
+						});
+					};
+					entity.test = 'tested';
+					entity.replace().then(() => {
+						expect(replaceCalled).toBeTruthy();
+						expect(Object.assign({}, entity)).toEqual({
+							test: 'tested',
+							testing: 'test',
+							dynamic: true
+						});
+						done();
+					});
 				});
-			};
-			entity.test = 'tested';
-			entity.replace().then(() => {
-				expect(replaceCalled).toBeTruthy();
-				expect(Object.assign({}, entity)).toEqual({
-					test: 'tested',
-					testing: 'test',
-					dynamic: true
-				});
-				done();
-			});
-		});
 
 		it('should use deserialized entity data in the dynamic create method',
 				(done) => {
-			let entity = new TransformingEntity(restClient, {
-				test: 'testing',
-				testing: 'test',
-				serialized: true
-			});
-			let createCalled = false;
-			restClientCallbacks.create = (data) => {
-				createCalled = true;
-				expect(data).toEqual({
-					test: 'testing',
-					testing: 'test',
-					serialized: true
+					let entity = new TransformingEntity(restClient, {
+						test: 'testing',
+						testing: 'test',
+						serialized: true
+					});
+					let createCalled = false;
+					restClientCallbacks.create = (data) => {
+						createCalled = true;
+						expect(data).toEqual({
+							test: 'testing',
+							testing: 'test',
+							serialized: true
+						});
+					};
+					entity.create().then(() => {
+						expect(createCalled).toBeTruthy();
+						expect(Object.assign({}, entity)).toEqual({
+							test: 'testing',
+							testing: 'test',
+							dynamic: true
+						});
+						done();
+					});
 				});
-			};
-			entity.create().then(() => {
-				expect(createCalled).toBeTruthy();
-				expect(Object.assign({}, entity)).toEqual({
-					test: 'testing',
-					testing: 'test',
-					dynamic: true
-				});
-				done();
-			});
-		});
 
 		it('should allow declarative property mapping', () => {
 			class DeclarativelyMappedEntity extends Entity {
@@ -422,69 +448,69 @@ describe('AbstractEntity', () => {
 
 		it('should allow declarative property mapping using mapper object',
 				() => {
-			class MappingEntity extends Entity {
-				static get dataFieldMapping() {
-					return {
-						id: {
-							dataFieldName: '_id',
-							serialize(value, processedEntity) {
-								expect(
+					class MappingEntity extends Entity {
+						static get dataFieldMapping() {
+							return {
+								id: {
+									dataFieldName: '_id',
+									serialize(value, processedEntity) {
+										expect(
 									processedEntity instanceof MappingEntity
 								).toBe(true);
-								return -value;
-							},
-							deserialize(value, processedEntity) {
-								expect(
+										return -value;
+									},
+									deserialize(value, processedEntity) {
+										expect(
 									processedEntity instanceof MappingEntity
 								).toBe(true);
-								return -value;
-							}
-						},
-						foo: {
-							dataFieldName: null,
-							serialize(value, processedEntity) {
-								return value;
-							},
-							deserialize(value, processedEntity) {
-								return value
-							}
-						},
-						bar: {
-							dataFieldName: 'bar',
-							serialize(value, processedEntity) {
-								return value;
-							},
-							deserialize(value, processedEntity) {
-								return value
-							}
+										return -value;
+									}
+								},
+								foo: {
+									dataFieldName: null,
+									serialize(value, processedEntity) {
+										return value;
+									},
+									deserialize(value, processedEntity) {
+										return value;
+									}
+								},
+								bar: {
+									dataFieldName: 'bar',
+									serialize(value, processedEntity) {
+										return value;
+									},
+									deserialize(value, processedEntity) {
+										return value;
+									}
+								}
+							};
 						}
-					};
-				}
 			}
 
-			let entity = new MappingEntity(restClient, {
-				_id: 123,
-				foo: 'a',
-				bar: 'b'
-			});
-			expect(Object.assign({}, entity)).toEqual({
-				id: -123,
-				foo: 'a',
-				bar: 'b'
-			});
-			expect(entity.$serialize()).toEqual({
-				_id: 123,
-				foo: 'a',
-				bar: 'b'
-			});
-		});
+					let entity = new MappingEntity(restClient, {
+						_id: 123,
+						foo: 'a',
+						bar: 'b'
+					});
+					expect(Object.assign({}, entity)).toEqual({
+						id: -123,
+						foo: 'a',
+						bar: 'b'
+					});
+					expect(entity.$serialize()).toEqual({
+						_id: 123,
+						foo: 'a',
+						bar: 'b'
+					});
+				});
 
 		it('should allow declarative property mapping using mapper classes',
 				() => {
-			class MappingEntity extends Entity {
-				static get dataFieldMapping() {
-					return {
-						id: AbstractDataFieldMapper.makeMapper(
+					class MappingEntity extends Entity {
+						static get dataFieldMapping() {
+							return {
+								id: AbstractDataFieldMapper.makeMapper(
 							'_id',
 							(value, processedEntity) => {
 								expect(
@@ -499,36 +525,36 @@ describe('AbstractEntity', () => {
 								return -value;
 							}
 						),
-						foo: AbstractDataFieldMapper.makeMapper(
+								foo: AbstractDataFieldMapper.makeMapper(
 							null,
 							value => value,
 							value => value
 						),
-						bar: AbstractDataFieldMapper.makeMapper(
+								bar: AbstractDataFieldMapper.makeMapper(
 							'bar',
 							value => value,
 							value => value
 						)
-					};
-				}
+							};
+						}
 			}
 
-			let entity = new MappingEntity(restClient, {
-				_id: 123,
-				foo: 'a',
-				bar: 'b'
-			});
-			expect(Object.assign({}, entity)).toEqual({
-				id: -123,
-				foo: 'a',
-				bar: 'b'
-			});
-			expect(entity.$serialize()).toEqual({
-				_id: 123,
-				foo: 'a',
-				bar: 'b'
-			});
-		});
+					let entity = new MappingEntity(restClient, {
+						_id: 123,
+						foo: 'a',
+						bar: 'b'
+					});
+					expect(Object.assign({}, entity)).toEqual({
+						id: -123,
+						foo: 'a',
+						bar: 'b'
+					});
+					expect(entity.$serialize()).toEqual({
+						_id: 123,
+						foo: 'a',
+						bar: 'b'
+					});
+				});
 
 		it('should allow create field mappers from entity classes', () => {
 			class Session extends Entity {}
@@ -693,8 +719,8 @@ describe('AbstractEntity', () => {
 
 		it('should be possible to configure inlineResponseBody exactly once',
 				() => {
-			testStaticProperty('inlineResponseBody', false, false, true);
-		});
+					testStaticProperty('inlineResponseBody', false, false, true);
+				});
 
 		it('should be possible to configure propTypes exactly once', () => {
 			testStaticProperty('propTypes', {}, false, { id: 'integer:>0' });
@@ -702,8 +728,8 @@ describe('AbstractEntity', () => {
 
 		it('should be possible to configure dataFieldMapping exactly once',
 				() => {
-			testStaticProperty('dataFieldMapping', {}, false, { id: '_id' });
-		});
+					testStaticProperty('dataFieldMapping', {}, false, { id: '_id' });
+				});
 
 		it('should be possible to configure isImmutable exactly once', () => {
 			testStaticProperty('isImmutable', false, false, true);
@@ -755,5 +781,5 @@ describe('AbstractEntity', () => {
 		}
 
 	});
-	
+
 });


### PR DESCRIPTION
`delete`, `patch`, `replace` and `create` methods now accept `parameters` argument.
This PR should be considered as a breaking change due to new method arguments appearing before other frequently used arguments.